### PR TITLE
Feature/add standard palettes

### DIFF
--- a/R/default_styles.R
+++ b/R/default_styles.R
@@ -4,8 +4,13 @@ datasketch_style <- function(){
     palette = c("#385573", "#ffa92a", "#f06142",
                 "#99e8b3", "#32a8ce", "#996295",
                 "#e59fd7"),
+    sequential = c("#ff91ff", "#f082f8", "#dd77f1",
+                   "#c66eeb", "#a968e5", "#8465e0",
+                   "#4f63db"),
+    divergent = c('#6f56fa', '#ad87fc', '#d6bdfb',
+                  '#f7f5f7', '#ffc9aa', '#ff9791',
+                  '#fc4eb9'),
     background = "#fafafa",
     na = "#d1d9db"
   )
 }
-

--- a/R/default_styles.R
+++ b/R/default_styles.R
@@ -4,12 +4,12 @@ datasketch_style <- function(){
     palette = c("#385573", "#ffa92a", "#f06142",
                 "#99e8b3", "#32a8ce", "#996295",
                 "#e59fd7"),
-    sequential = c("#ff91ff", "#f082f8", "#dd77f1",
-                   "#c66eeb", "#a968e5", "#8465e0",
-                   "#4f63db"),
-    divergent = c('#6f56fa', '#ad87fc', '#d6bdfb',
-                  '#f7f5f7', '#ffc9aa', '#ff9791',
-                  '#fc4eb9'),
+    sequential = c("#b8f3ca", "#add79c", "#8dbd93",
+                   "#70a38e", "#568989", "#3f6f83",
+                   "#28557d"),
+    divergent = c("#ff844e", "#ffa154", "#ffc48b",
+                  "#eef0f1", "#a0d7ca", "#57a0b5",
+                  "#255b89"),
     background = "#fafafa",
     na = "#d1d9db"
   )

--- a/R/options.R
+++ b/R/options.R
@@ -173,6 +173,7 @@ dsviz_default_opts <- function(drop_na = NULL,
   dataLabelsOpts <- list(
     dataLabels_show = FALSE,
     dataLabels_format_sample = NULL,
+    dataLabels_type = NULL,
     dataLabels_size = NULL,
     dataLabels_color = NULL,
     dataLabels_text_outline = TRUE

--- a/R/theme.R
+++ b/R/theme.R
@@ -112,6 +112,8 @@ default_theme_opts <- function( logo = NULL,
 
 
     palette_colors = datasketch_style()$palette,
+    palette_colors_sequential = datasketch_style()$sequential,
+    palette_colors_divergent = datasketch_style()$divergent,
     na_color = "#cbcdcf",
 
     branding_include = FALSE,


### PR DESCRIPTION
This branch is based on #16 --> merge #16 first or rebase this one on master.

Added parameters `palette_colors_sequential` and `palette_colors_divergent` to `default_theme_opts` so that they can be used for maps with numerical values. 

I used Sequential1 and Divergent1 from the dark theme in dsthemer (https://github.com/datasketch/dsthemer/blob/master/inst/themes/datasketch.yaml).